### PR TITLE
Update the BrowserWindow & Tray icons to use the nativeimage setting

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,7 +18,7 @@ createWindow = () => {
         width: 1280,
         height: 720,
         title: 'Home Assistant Desktop',
-        icon: __dirname + '/images/HomeAssistant.ico',
+        icon: nativeImage.createFromPath(__dirname + '/images/HomeAssistant.png'),
         autoHideMenuBar: true,
         webPreferences: {
             contextIsolation: false,
@@ -54,7 +54,7 @@ createWindow = () => {
         .catch(console.error);
     }
 
-    const icon = nativeImage.createFromPath(__dirname + '/images/HomeAssistant.ico')
+    const icon = nativeImage.createFromPath(__dirname + '/images/HomeAssistant.png')
     tray = new Tray(icon)
 
     const contextMenu = Menu.buildFromTemplate([


### PR DESCRIPTION
This fix is to set the BrowserWindow & Tray icon to use the [nativeImage](https://www.electronjs.org/docs/latest/api/native-image) setting, instead of the direct path.